### PR TITLE
Implement Subset feature

### DIFF
--- a/lib/models/subset.dart
+++ b/lib/models/subset.dart
@@ -1,0 +1,31 @@
+class Subset {
+  final int? id;
+  final int? from;
+  final int? to;
+  final int? vocId;
+
+  const Subset({
+    this.id,
+    this.from,
+    this.to,
+    this.vocId,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'from': from,
+      'to': to,
+      'vocId': vocId,
+    };
+  }
+
+  factory Subset.fromMap(Map<String, dynamic> map) {
+    return Subset(
+      id: map['id'],
+      from: map['from'],
+      to: map['to'],
+      vocId: map['vocId'],
+    );
+  }
+}

--- a/lib/utilities/database.dart
+++ b/lib/utilities/database.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:quizflow/models/subset.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -11,7 +12,7 @@ class DatabaseService {
   static Database? db;
 
   static const databaseVersion = 1;
-  List<String> tables = ["Vocs", "Words"];
+  List<String> tables = ["Vocs", "Words", "Subsets"];
 
   static Future<Database> initializeDb() async {
     final databasePath = (await getApplicationDocumentsDirectory()).path;
@@ -61,6 +62,15 @@ class DatabaseService {
           vocId INTEGER
       )
     """);
+
+    await database.execute("""
+      CREATE TABLE Subsets(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          from INTEGER,
+          to INTEGER,
+          vocId INTEGER
+      )
+    """);
   }
 
   static Future<int> createVoc(Voc voc) async {
@@ -79,6 +89,13 @@ class DatabaseService {
     return id;
   }
 
+  static Future<int> createSubset(Subset subset) async {
+    final db = await DatabaseService.initializeDb();
+
+    final id = await db.insert('Subsets', subset.toMap());
+    return id;
+  }
+
   static Future<List<Voc>> getVocs({String searchQuery = ""}) async {
     final db = await DatabaseService.initializeDb();
 
@@ -88,10 +105,18 @@ class DatabaseService {
     return queryResult.map((e) => Voc.fromMap(e)).toList();
   }
 
-  static Future<List<Word>> getWord() async {
+  static Future<List<Word>> getWords() async {
     final db = await DatabaseService.initializeDb();
 
     List<Map<String, dynamic>> queryResult = await db.query('Words');
+
+    return queryResult.map((e) => Word.fromMap(e)).toList();
+  }
+
+  static Future<List<Word>> getSubsets() async {
+    final db = await DatabaseService.initializeDb();
+
+    List<Map<String, dynamic>> queryResult = await db.query('Subsets');
 
     return queryResult.map((e) => Word.fromMap(e)).toList();
   }
@@ -105,6 +130,15 @@ class DatabaseService {
     return vocWords.map((e) => Word.fromMap(e)).toList();
   }
 
+  static Future<List<Subset>> getSubsetsFromVoc(int vocId) async {
+    final db = await DatabaseService.initializeDb();
+
+    List<Map<String, dynamic>> vocSubsets =
+        await db.query('Subsets', where: "vocId = $vocId");
+
+    return vocSubsets.map((e) => Subset.fromMap(e)).toList();
+  }
+
   static Future<void> removeVoc(int vocId) async {
     final db = await DatabaseService.initializeDb();
     db.delete("Vocs", where: "id = $vocId");
@@ -116,9 +150,19 @@ class DatabaseService {
     db.delete("Words", where: "id = $wordId");
   }
 
+  static Future<void> removeSubset(int subsetId) async {
+    final db = await DatabaseService.initializeDb();
+    db.delete("Subsets", where: "id = $subsetId");
+  }
+
   static Future<void> removeWordsFromVoc(int vocId) async {
     final db = await DatabaseService.initializeDb();
     db.delete("Words", where: "vocId = $vocId");
+  }
+
+  static Future<void> removeSubsetsFromVoc(int vocId) async {
+    final db = await DatabaseService.initializeDb();
+    db.delete("Subsets", where: "vocId = $vocId");
   }
 
   static Future<void> updateVoc(Voc voc) async {
@@ -134,11 +178,27 @@ class DatabaseService {
     db.update("Words", word.toMap(), where: 'id = ?', whereArgs: [word.id]);
   }
 
+  static Future<void> updateSubset(Subset subset) async {
+    print("UPDATE");
+
+    final db = await DatabaseService.initializeDb();
+
+    db.update("Subsets", subset.toMap(),
+        where: 'id = ?', whereArgs: [subset.id]);
+  }
+
   static Future<String> exportVoc(Voc voc) async {
     List<Word> words = await getWordsFromVoc(voc.id!);
+    List<Subset> subsets = await getSubsetsFromVoc(voc.id!);
+
     Map result = voc.toMap();
+
     List<Map<dynamic, dynamic>> wordsMap = words.map((e) => e.toMap()).toList();
+    List<Map<dynamic, dynamic>> subsetsMap =
+        subsets.map((e) => e.toMap()).toList();
+
     result["words"] = wordsMap;
+    result["subsets"] = subsetsMap;
     return jsonEncode(result);
   }
 
@@ -146,7 +206,10 @@ class DatabaseService {
     Map<String, dynamic> jsonData = jsonDecode(backup);
     Voc voc = Voc.fromMap(jsonData);
     int vocId = await createVoc(voc);
+
     List wordsMap = jsonData["words"];
+    List subsetsMap = jsonData["subsets"];
+
     for (var i = 0; i < wordsMap.length; i++) {
       Map<String, dynamic> wordMap = wordsMap[i];
       wordMap["vocId"] = vocId;
@@ -154,6 +217,15 @@ class DatabaseService {
 
       Word word = Word.fromMap(wordMap);
       await createWord(word);
+    }
+
+    for (var i = 0; i < subsetsMap.length; i++) {
+      Map<String, dynamic> subsetMap = subsetsMap[i];
+      subsetMap["vocId"] = vocId;
+      print(subsetMap);
+
+      Subset subset = Subset.fromMap(subsetMap);
+      await createSubset(subset);
     }
   }
 

--- a/lib/utilities/database.dart
+++ b/lib/utilities/database.dart
@@ -66,8 +66,8 @@ class DatabaseService {
     await database.execute("""
       CREATE TABLE Subsets(
           id INTEGER PRIMARY KEY AUTOINCREMENT,
-          from INTEGER,
-          to INTEGER,
+          "from" INTEGER,
+          "to" INTEGER,
           vocId INTEGER
       )
     """);

--- a/lib/widgets/dismissible_card.dart
+++ b/lib/widgets/dismissible_card.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class DismissibleCard extends StatefulWidget {
+  final ValueNotifier<List<DismissibleCard>> editorCards;
+  final List<List<dynamic>> textControllers;
+  final Widget child;
+  final VoidCallback onItemRemoved;
+
+  const DismissibleCard({
+    super.key,
+    required this.editorCards,
+    this.textControllers = const [
+      [null]
+    ],
+    required this.child,
+    required this.onItemRemoved,
+  });
+
+  @override
+  State<DismissibleCard> createState() => _DismissibleCardState();
+}
+
+class _DismissibleCardState extends State<DismissibleCard> {
+  void removeEditorCards(int index) {
+    if (index >= 0 && index < widget.editorCards.value.length) {
+      widget.editorCards.value = List.from(widget.editorCards.value)
+        ..removeAt(index);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      direction: DismissDirection.endToStart,
+      onDismissed: (DismissDirection direction) {
+        print('Dismissed with direction $direction');
+
+        setState(() {
+          if (widget.textControllers !=
+              [
+                [null]
+              ]) {
+            widget.textControllers
+                .removeAt(widget.editorCards.value.indexOf(widget));
+          }
+
+          widget.editorCards.value = List.from(widget.editorCards.value)
+            ..remove(widget);
+          widget.onItemRemoved();
+        });
+      },
+      // confirmDismiss:
+      //     (DismissDirection direction) async {
+      //   return false;
+      // },
+      background: const ColoredBox(
+        color: Colors.red,
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Icon(Icons.delete, color: Colors.white),
+          ),
+        ),
+      ),
+      key: UniqueKey(),
+      child: widget.child,
+    );
+  }
+}

--- a/lib/widgets/dismissible_card.dart
+++ b/lib/widgets/dismissible_card.dart
@@ -2,16 +2,12 @@ import 'package:flutter/material.dart';
 
 class DismissibleCard extends StatefulWidget {
   final ValueNotifier<List<DismissibleCard>> editorCards;
-  final List<List<dynamic>> textControllers;
   final Widget child;
   final VoidCallback onItemRemoved;
 
   const DismissibleCard({
     super.key,
     required this.editorCards,
-    this.textControllers = const [
-      [null]
-    ],
     required this.child,
     required this.onItemRemoved,
   });
@@ -21,13 +17,6 @@ class DismissibleCard extends StatefulWidget {
 }
 
 class _DismissibleCardState extends State<DismissibleCard> {
-  void removeEditorCards(int index) {
-    if (index >= 0 && index < widget.editorCards.value.length) {
-      widget.editorCards.value = List.from(widget.editorCards.value)
-        ..removeAt(index);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Dismissible(
@@ -36,14 +25,6 @@ class _DismissibleCardState extends State<DismissibleCard> {
         print('Dismissed with direction $direction');
 
         setState(() {
-          if (widget.textControllers !=
-              [
-                [null]
-              ]) {
-            widget.textControllers
-                .removeAt(widget.editorCards.value.indexOf(widget));
-          }
-
           widget.editorCards.value = List.from(widget.editorCards.value)
             ..remove(widget);
           widget.onItemRemoved();

--- a/lib/widgets/subset_card.dart
+++ b/lib/widgets/subset_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/models/word.dart';
+import 'package:quizflow/pages_layout.dart';
+import 'package:quizflow/widgets/flashcards_page.dart';
+import 'package:quizflow/widgets/write_page.dart';
+
+class SubsetCard extends StatelessWidget {
+  final List<Word> words;
+
+  const SubsetCard({super.key, required this.words});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          children: [
+            Column(
+              children: [
+                Text(words.first.word ?? ""),
+                const Text("-"),
+                Text(words.last.word ?? "")
+              ],
+            ),
+            const Spacer(),
+            Column(
+              children: [
+                IconButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                            builder: (context) => PagesLayout(
+                                displayNavBar: false,
+                                child: WritePage(
+                                  words: words,
+                                ))),
+                      );
+                    },
+                    icon: const Icon(Icons.edit_note)),
+                IconButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                            builder: (context) => PagesLayout(
+                                displayNavBar: false,
+                                child: FlashcardsPage(
+                                  words: words,
+                                ))),
+                      );
+                    },
+                    icon: const Icon(Icons.dynamic_feed))
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/subset_editor_card.dart
+++ b/lib/widgets/subset_editor_card.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/widgets/dismissible_card.dart';
+import 'package:quizflow/widgets/word_editor_card.dart';
+
+// ignore: must_be_immutable
+class SubsetEditorCard extends StatefulWidget {
+  final ValueNotifier<List<DismissibleCard>> wordEditorCardsNotifier;
+  int from;
+  int to;
+
+  SubsetEditorCard(
+      {super.key,
+      required this.wordEditorCardsNotifier,
+      required this.from,
+      required this.to});
+
+  @override
+  State<SubsetEditorCard> createState() => _SubsetEditorCardState();
+}
+
+class _SubsetEditorCardState extends State<SubsetEditorCard> {
+  bool isFromSelected = false;
+  bool isToSelected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<DismissibleCard>>(
+        valueListenable: widget.wordEditorCardsNotifier,
+        builder: (context, wordEditorCards, child) {
+          return Card(
+              child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      Autocomplete<String>(
+                        optionsBuilder:
+                            (TextEditingValue textEditingValue) async {
+                          if (textEditingValue.text.isEmpty ||
+                              widget.wordEditorCardsNotifier.value.isEmpty) {
+                            return const Iterable<String>.empty();
+                          }
+
+                          return widget.wordEditorCardsNotifier.value.map((e) {
+                            if (e.child is WordEditorCard &&
+                                (e.child as WordEditorCard)
+                                    .questionController
+                                    .text
+                                    .isNotEmpty &&
+                                (e.child as WordEditorCard)
+                                    .answerController
+                                    .text
+                                    .isNotEmpty) {
+                              return (e.child as WordEditorCard)
+                                  .questionController
+                                  .text;
+                            }
+                          }).where((String? option) {
+                            return option != null &&
+                                option.isNotEmpty &&
+                                (widget.to == -1 ||
+                                    widget.wordEditorCardsNotifier.value
+                                            .indexWhere((element) {
+                                          if (element.child is WordEditorCard) {
+                                            return (element.child
+                                                        as WordEditorCard)
+                                                    .questionController
+                                                    .text
+                                                    .toLowerCase() ==
+                                                option.toLowerCase();
+                                          } else {
+                                            return false;
+                                          }
+                                        }) <
+                                        widget.to) &&
+                                option.toLowerCase().contains(
+                                    textEditingValue.text.toLowerCase());
+                          }).cast<String>();
+                        },
+                        onSelected: (String selection) {
+                          setState(() {
+                            widget.from = widget.wordEditorCardsNotifier.value
+                                .indexWhere((element) {
+                              if (element.child is WordEditorCard) {
+                                return (element.child as WordEditorCard)
+                                        .questionController
+                                        .text ==
+                                    selection;
+                              } else {
+                                return false;
+                              }
+                            });
+                            isFromSelected = true;
+                          });
+                        },
+                        fieldViewBuilder: (BuildContext context,
+                            TextEditingController textEditingController,
+                            FocusNode focusNode,
+                            VoidCallback onFieldSubmitted) {
+                          if (widget.from != -1 &&
+                              widget.wordEditorCardsNotifier.value[widget.from]
+                                  .child is WordEditorCard) {
+                            if (textEditingController.text != "" &&
+                                (widget
+                                            .wordEditorCardsNotifier
+                                            .value[widget.from]
+                                            .child as WordEditorCard)
+                                        .questionController
+                                        .text !=
+                                    textEditingController.text) {
+                              widget.from = -1;
+                              widget.to -= 1;
+                              textEditingController.clear();
+                            } else {
+                              textEditingController.text = (widget
+                                      .wordEditorCardsNotifier
+                                      .value[widget.from]
+                                      .child as WordEditorCard)
+                                  .questionController
+                                  .text;
+                            }
+                          }
+
+                          focusNode.addListener(() {
+                            if (!focusNode.hasFocus) {
+                              if (!isFromSelected) {
+                                if (widget.from != -1 &&
+                                    widget
+                                        .wordEditorCardsNotifier
+                                        .value[widget.from]
+                                        .child is WordEditorCard) {
+                                  if (textEditingController.text != "") {
+                                    textEditingController.text = (widget
+                                            .wordEditorCardsNotifier
+                                            .value[widget.from]
+                                            .child as WordEditorCard)
+                                        .questionController
+                                        .text;
+                                  } else {
+                                    widget.from = -1;
+                                  }
+                                } else {
+                                  textEditingController.clear();
+                                }
+                              }
+                              isFromSelected = false;
+                            }
+                          });
+
+                          return TextField(
+                            controller: textEditingController,
+                            focusNode: focusNode,
+                            decoration: const InputDecoration(
+                              border: UnderlineInputBorder(),
+                              labelText: 'From',
+                            ),
+                          );
+                        },
+                      ),
+                      Autocomplete<String>(
+                        optionsBuilder:
+                            (TextEditingValue textEditingValue) async {
+                          if (textEditingValue.text.isEmpty) {
+                            return const Iterable<String>.empty();
+                          }
+
+                          return widget.wordEditorCardsNotifier.value.map((e) {
+                            if (e.child is WordEditorCard &&
+                                (e.child as WordEditorCard)
+                                    .questionController
+                                    .text
+                                    .isNotEmpty &&
+                                (e.child as WordEditorCard)
+                                    .answerController
+                                    .text
+                                    .isNotEmpty) {
+                              return (e.child as WordEditorCard)
+                                  .questionController
+                                  .text;
+                            }
+                          }).where((String? option) {
+                            return option != null &&
+                                option.isNotEmpty &&
+                                widget.wordEditorCardsNotifier.value
+                                        .indexWhere((element) {
+                                      if (element.child is WordEditorCard) {
+                                        return (element.child as WordEditorCard)
+                                                .questionController
+                                                .text
+                                                .toLowerCase() ==
+                                            option.toLowerCase();
+                                      } else {
+                                        return false;
+                                      }
+                                    }) >
+                                    widget.from &&
+                                option.toLowerCase().contains(
+                                    textEditingValue.text.toLowerCase());
+                          }).cast<String>();
+                        },
+                        onSelected: (String selection) {
+                          setState(() {
+                            widget.to = widget.wordEditorCardsNotifier.value
+                                .indexWhere((element) {
+                              if (element.child is WordEditorCard) {
+                                return (element.child as WordEditorCard)
+                                        .questionController
+                                        .text ==
+                                    selection;
+                              } else {
+                                return false;
+                              }
+                            });
+                            isToSelected = true;
+                          });
+                        },
+                        fieldViewBuilder: (BuildContext context,
+                            TextEditingController textEditingController,
+                            FocusNode focusNode,
+                            VoidCallback onFieldSubmitted) {
+                          if (widget.to != -1 &&
+                              widget.to <
+                                  widget.wordEditorCardsNotifier.value.length &&
+                              widget.wordEditorCardsNotifier.value[widget.to]
+                                  .child is WordEditorCard) {
+                            if (textEditingController.text != "" &&
+                                (widget.wordEditorCardsNotifier.value[widget.to]
+                                            .child as WordEditorCard)
+                                        .questionController
+                                        .text !=
+                                    textEditingController.text) {
+                              widget.to = -1;
+                              textEditingController.clear();
+                            } else {
+                              textEditingController.text = (widget
+                                      .wordEditorCardsNotifier
+                                      .value[widget.to]
+                                      .child as WordEditorCard)
+                                  .questionController
+                                  .text;
+                            }
+                          } else {
+                            widget.to = -1;
+                            textEditingController.clear();
+                          }
+
+                          focusNode.addListener(() {
+                            if (!focusNode.hasFocus) {
+                              if (!isToSelected) {
+                                if (widget.to != -1 &&
+                                    widget
+                                        .wordEditorCardsNotifier
+                                        .value[widget.to]
+                                        .child is WordEditorCard) {
+                                  if (textEditingController.text != "") {
+                                    textEditingController.text = (widget
+                                            .wordEditorCardsNotifier
+                                            .value[widget.to]
+                                            .child as WordEditorCard)
+                                        .questionController
+                                        .text;
+                                  } else {
+                                    widget.to = -1;
+                                  }
+                                } else {
+                                  textEditingController.clear();
+                                }
+                              }
+                              isToSelected = false;
+                            }
+                          });
+
+                          return TextField(
+                            controller: textEditingController,
+                            focusNode: focusNode,
+                            decoration: const InputDecoration(
+                              border: UnderlineInputBorder(),
+                              labelText: 'To',
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  )));
+        });
+  }
+}

--- a/lib/widgets/voc_details_page.dart
+++ b/lib/widgets/voc_details_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:quizflow/models/subset.dart';
 import 'package:quizflow/models/voc.dart';
 import 'package:quizflow/models/word.dart';
 import 'package:quizflow/pages_layout.dart';
@@ -6,6 +7,7 @@ import 'package:quizflow/utilities/database.dart';
 import 'package:quizflow/utilities/utils.dart';
 import 'package:quizflow/widgets/flashcards_page.dart';
 import 'package:quizflow/widgets/home_page.dart';
+import 'package:quizflow/widgets/subset_card.dart';
 import 'package:quizflow/widgets/voc_editor_page.dart';
 import 'package:quizflow/widgets/word_card.dart';
 import 'package:quizflow/widgets/write_page.dart';
@@ -20,6 +22,7 @@ class VocDetailsPage extends StatefulWidget {
 
 class _VocDetailsPageState extends State<VocDetailsPage> {
   List<Word> words = [];
+  List<Subset> subsets = [];
 
   Future<void> loadWords() async {
     DatabaseService.getWordsFromVoc(widget.voc.id!).then((value) {
@@ -29,9 +32,18 @@ class _VocDetailsPageState extends State<VocDetailsPage> {
     });
   }
 
+  Future<void> loadSubsets() async {
+    DatabaseService.getSubsetsFromVoc(widget.voc.id!).then((value) {
+      setState(() {
+        subsets = value;
+      });
+    });
+  }
+
   @override
   void initState() {
     loadWords();
+    loadSubsets();
     super.initState();
   }
 
@@ -71,6 +83,7 @@ class _VocDetailsPageState extends State<VocDetailsPage> {
                 MaterialPageRoute(
                     builder: (context) => VocEditorPage(
                           initialVoc: widget.voc,
+                          initialSubsets: subsets,
                           initialWords: words,
                         )),
               );
@@ -136,6 +149,20 @@ class _VocDetailsPageState extends State<VocDetailsPage> {
                   icon: const Icon(Icons.dynamic_feed),
                 ),
               ),
+              const SizedBox(height: 30),
+              const Text(
+                "Subsets:",
+                style: TextStyle(fontSize: 20),
+              ),
+              ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: subsets.length,
+                  itemBuilder: (context, index) {
+                    return SubsetCard(
+                        words: words.sublist(subsets[index].from ?? 0,
+                            (subsets[index].to ?? words.length - 1) + 1));
+                  }),
               const SizedBox(height: 30),
               const Text(
                 "Words:",

--- a/lib/widgets/voc_editor_page.dart
+++ b/lib/widgets/voc_editor_page.dart
@@ -2,17 +2,22 @@ import 'dart:convert';
 
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+import 'package:quizflow/models/subset.dart';
 import 'package:quizflow/models/voc.dart';
 import 'package:quizflow/models/word.dart';
 import 'package:quizflow/pages_layout.dart';
 import 'package:quizflow/utilities/database.dart';
+import 'package:quizflow/widgets/dismissible_card.dart';
 import 'package:quizflow/widgets/home_page.dart';
+import 'package:quizflow/widgets/subset_editor_card.dart';
 import 'package:quizflow/widgets/word_editor_card.dart';
 
 class VocEditorPage extends StatefulWidget {
+  final List<Subset>? initialSubsets;
   final List<Word>? initialWords;
   final Voc? initialVoc;
-  const VocEditorPage({super.key, this.initialWords, this.initialVoc});
+  const VocEditorPage(
+      {super.key, this.initialWords, this.initialVoc, this.initialSubsets});
 
   @override
   State<VocEditorPage> createState() => _VocEditorPageState();
@@ -22,42 +27,25 @@ class _VocEditorPageState extends State<VocEditorPage> {
   final newVocFormKey = GlobalKey<FormState>();
   String title = "";
   String description = "";
-  List<Widget> wordsCards = [];
+  ValueNotifier<List<DismissibleCard>> wordsCards = ValueNotifier([]);
+  ValueNotifier<List<DismissibleCard>> subsetsCards = ValueNotifier([]);
   List<List<TextEditingController>> wordsControllers = [];
   TextEditingController titleController = TextEditingController();
   TextEditingController descriptionController = TextEditingController();
 
-  void newCard({Word? initialWord}) {
+  void newWordCard({Word? initialWord}) {
     setState(() {
       TextEditingController questionController =
           TextEditingController(text: initialWord?.word ?? "");
       TextEditingController answerController =
           TextEditingController(text: initialWord?.answer ?? "");
 
-      int wordIndex = wordsControllers.length + 1;
-
-      wordsCards.add(Dismissible(
-        direction: DismissDirection.endToStart,
-        onDismissed: (DismissDirection direction) {
-          print('Dismissed with direction $direction');
-          print(answerController.text);
-          wordsControllers.removeAt(wordIndex);
+      wordsCards.value.add(DismissibleCard(
+        editorCards: wordsCards,
+        textControllers: wordsControllers,
+        onItemRemoved: () {
+          setState(() {});
         },
-        // confirmDismiss:
-        //     (DismissDirection direction) async {
-        //   return false;
-        // },
-        background: const ColoredBox(
-          color: Colors.red,
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: Padding(
-              padding: EdgeInsets.all(16.0),
-              child: Icon(Icons.delete, color: Colors.white),
-            ),
-          ),
-        ),
-        key: UniqueKey(),
         child: WordEditorCard(
           questionController: questionController,
           answerController: answerController,
@@ -65,6 +53,25 @@ class _VocEditorPageState extends State<VocEditorPage> {
       ));
 
       wordsControllers.add([questionController, answerController]);
+    });
+  }
+
+  void newSubsetCard({Subset? initialSubset}) {
+    setState(() {
+      int from = initialSubset?.from ?? -1;
+      int to = initialSubset?.to ?? -1;
+
+      subsetsCards.value.add(DismissibleCard(
+        editorCards: subsetsCards,
+        onItemRemoved: () {
+          setState(() {});
+        },
+        child: SubsetEditorCard(
+          wordEditorCardsNotifier: wordsCards,
+          from: from,
+          to: to,
+        ),
+      ));
     });
   }
 
@@ -96,6 +103,22 @@ class _VocEditorPageState extends State<VocEditorPage> {
             answer: wordsControllers[i][1].text));
       }
     }
+    if (widget.initialSubsets != null) {
+      // TO BE FIXED !;
+      print("updates subsets");
+      await DatabaseService.removeSubsetsFromVoc(vocId);
+    }
+    for (int i = 0; i < subsetsCards.value.length; i++) {
+      print(subsetsCards.value[i]);
+      if (subsetsCards.value[i].child is SubsetEditorCard &&
+          (subsetsCards.value[i].child as SubsetEditorCard).from != -1 &&
+          (subsetsCards.value[i].child as SubsetEditorCard).to != -1) {
+        await DatabaseService.createSubset(Subset(
+            vocId: vocId,
+            from: (subsetsCards.value[i].child as SubsetEditorCard).from,
+            to: (subsetsCards.value[i].child as SubsetEditorCard).to));
+      }
+    }
     return;
   }
 
@@ -109,11 +132,22 @@ class _VocEditorPageState extends State<VocEditorPage> {
     if (widget.initialWords != null) {
       print("BBBAA");
       for (Word word in widget.initialWords!) {
-        newCard(initialWord: word);
+        newWordCard(initialWord: word);
       }
     } else {
-      for (var i = 0; i < 4; i++) {
-        newCard();
+      for (var i = 0; i < 3; i++) {
+        newWordCard();
+      }
+    }
+
+    if (widget.initialSubsets != null) {
+      print("BBBAA");
+      for (Subset subset in widget.initialSubsets!) {
+        newSubsetCard(initialSubset: subset);
+      }
+    } else {
+      for (var i = 0; i < 1; i++) {
+        newSubsetCard();
       }
     }
     super.initState();
@@ -133,7 +167,10 @@ class _VocEditorPageState extends State<VocEditorPage> {
       Map<String, dynamic> data = jsonDecode(backupContent);
 
       for (var word in data["words"]) {
-        newCard(initialWord: Word.fromMap(word));
+        newWordCard(initialWord: Word.fromMap(word));
+      }
+      for (var subset in data["subsets"]) {
+        newSubsetCard(initialSubset: Subset.fromMap(subset));
       }
       titleController.text = data["title"];
       descriptionController.text = data["description"];
@@ -215,15 +252,37 @@ class _VocEditorPageState extends State<VocEditorPage> {
                   const SizedBox(height: 40),
                   Column(
                     children: [
+                      const Text(
+                        "Subsets:",
+                        style: TextStyle(fontSize: 20),
+                      ),
                       Column(
-                        children: wordsCards,
+                        children: subsetsCards.value,
                       ),
                       const SizedBox(
-                        height: 20,
+                        height: 10,
                       ),
                       ElevatedButton(
                           onPressed: () {
-                            newCard();
+                            newSubsetCard();
+                          },
+                          child: const Text("New")),
+                      const SizedBox(
+                        height: 40,
+                      ),
+                      const Text(
+                        "Words:",
+                        style: TextStyle(fontSize: 20),
+                      ),
+                      Column(
+                        children: wordsCards.value,
+                      ),
+                      const SizedBox(
+                        height: 10,
+                      ),
+                      ElevatedButton(
+                          onPressed: () {
+                            newWordCard();
                           },
                           child: const Text("New"))
                     ],

--- a/lib/widgets/voc_editor_page.dart
+++ b/lib/widgets/voc_editor_page.dart
@@ -29,7 +29,6 @@ class _VocEditorPageState extends State<VocEditorPage> {
   String description = "";
   ValueNotifier<List<DismissibleCard>> wordsCards = ValueNotifier([]);
   ValueNotifier<List<DismissibleCard>> subsetsCards = ValueNotifier([]);
-  List<List<TextEditingController>> wordsControllers = [];
   TextEditingController titleController = TextEditingController();
   TextEditingController descriptionController = TextEditingController();
 
@@ -42,7 +41,6 @@ class _VocEditorPageState extends State<VocEditorPage> {
 
       wordsCards.value.add(DismissibleCard(
         editorCards: wordsCards,
-        textControllers: wordsControllers,
         onItemRemoved: () {
           setState(() {});
         },
@@ -51,8 +49,6 @@ class _VocEditorPageState extends State<VocEditorPage> {
           answerController: answerController,
         ),
       ));
-
-      wordsControllers.add([questionController, answerController]);
     });
   }
 
@@ -94,13 +90,24 @@ class _VocEditorPageState extends State<VocEditorPage> {
       print("updates words");
       await DatabaseService.removeWordsFromVoc(vocId);
     }
-    for (int i = 0; i < wordsControllers.length; i++) {
-      if (wordsControllers[i][0].text.isNotEmpty &&
-          wordsControllers[i][1].text.isNotEmpty) {
+    for (int i = 0; i < wordsCards.value.length; i++) {
+      if (wordsCards.value[i].child is WordEditorCard &&
+          (wordsCards.value[i].child as WordEditorCard)
+              .questionController
+              .text
+              .isNotEmpty &&
+          (wordsCards.value[i].child as WordEditorCard)
+              .answerController
+              .text
+              .isNotEmpty) {
         await DatabaseService.createWord(Word(
             vocId: vocId,
-            word: wordsControllers[i][0].text,
-            answer: wordsControllers[i][1].text));
+            word: (wordsCards.value[i].child as WordEditorCard)
+                .questionController
+                .text,
+            answer: (wordsCards.value[i].child as WordEditorCard)
+                .answerController
+                .text));
       }
     }
     if (widget.initialSubsets != null) {
@@ -109,7 +116,6 @@ class _VocEditorPageState extends State<VocEditorPage> {
       await DatabaseService.removeSubsetsFromVoc(vocId);
     }
     for (int i = 0; i < subsetsCards.value.length; i++) {
-      print(subsetsCards.value[i]);
       if (subsetsCards.value[i].child is SubsetEditorCard &&
           (subsetsCards.value[i].child as SubsetEditorCard).from != -1 &&
           (subsetsCards.value[i].child as SubsetEditorCard).to != -1) {


### PR DESCRIPTION
This pull request introduces a new feature called Subsets, which are subsets of "Vocs" (vocabularies) that share common "Words" (entries). This change allows for the grouping of related Words within a specific Voc. A new database table has been created to store Subsets, each consisting of a range (from - to) and a vocId, which ties it to a specific Voc.

Changes:

    database.dart:
        Added the implementation of the Subset model and the corresponding logic to store and retrieve subsets from the database.

    dismissible_card.dart:
        Added to enhance the reusability of the Dismissible widget to be used with the subset and word editors respectively.

    subset_card.dart:
        Added a visual representation for subsets, mirroring the structure of word_card.dart.

    subset_editor_card.dart:
        Introduced SubsetEditorCard, similar to word_editor_card.dart, but customized for editing subsets.

    voc_details_page.dart:
        Integrated the main logic for handling subsets within the existing Voc detail view, using the sublist() method for managing subsets.

    voc_editor_page.dart:
        Added functionality to allow users to create and edit subsets in the voc editor.

This change improves the organization and management of vocabularies by allowing users to work with related subsets of words. It provides a more granular control over vocabularies, thus making it easier to manage larger datasets and improving overall usability.