### PR TITLE
Implement the option to add multiple answers to one word

### DIFF
--- a/lib/models/answer.dart
+++ b/lib/models/answer.dart
@@ -1,0 +1,21 @@
+class Answer {
+  final int? id;
+  final String? answer;
+  final int? wordId;
+  final int? vocId;
+
+  const Answer({this.id, this.answer, this.wordId, this.vocId});
+
+  Map<String, dynamic> toMap() {
+    return {'id': id, 'answer': answer, 'wordId': wordId, 'vocId': vocId};
+  }
+
+  factory Answer.fromMap(Map<String, dynamic> map) {
+    return Answer(
+      id: map['id'],
+      answer: map['answer'],
+      wordId: map['wordId'],
+      vocId: map['vocId'],
+    );
+  }
+}

--- a/lib/models/word.dart
+++ b/lib/models/word.dart
@@ -1,31 +1,15 @@
 class Word {
   final int? id;
   final String? word;
-  final String? answer;
   final int? vocId;
 
-  const Word({
-    this.id,
-    this.word,
-    this.answer,
-    this.vocId,
-  });
+  const Word({this.id, this.word, this.vocId});
 
   Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'word': word,
-      'definition': answer,
-      'vocId': vocId,
-    };
+    return {'id': id, 'word': word, 'vocId': vocId};
   }
 
   factory Word.fromMap(Map<String, dynamic> map) {
-    return Word(
-      id: map['id'],
-      word: map['word'],
-      answer: map['definition'],
-      vocId: map['vocId'],
-    );
+    return Word(id: map['id'], word: map['word'], vocId: map['vocId']);
   }
 }

--- a/lib/widgets/InputChip/chips_controller.dart
+++ b/lib/widgets/InputChip/chips_controller.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/models/answer.dart';
+
+class ChipsController extends ChangeNotifier {
+  final Set<String?> _chips = <String>{};
+
+  Set<String?> get chips => _chips;
+
+  ChipsController([List<Answer> initialChips = const []]) {
+    addAllChips(initialChips);
+  }
+
+  void addChip(String chip) {
+    _chips.add(chip);
+    notifyListeners();
+  }
+
+  void removeChip(String? chip) {
+    _chips.remove(chip);
+    notifyListeners();
+  }
+
+  void addAllChips(List<Answer> chips) {
+    for (Answer answer in chips) {
+      _chips.add(answer.answer);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/widgets/InputChip/flutter_chips.dart
+++ b/lib/widgets/InputChip/flutter_chips.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/widgets/InputChip/chips_controller.dart';
+
+class FlutterChips extends StatefulWidget {
+  final ChipsController controller;
+
+  /// enables the input field and chip delete ability
+  final bool enabled;
+
+  /// returns a list of string on inout field submitted
+  final ValueChanged<Set<String?>> onChanged;
+
+  /// custom delete icon
+  final Widget? chipDeleteIcon;
+
+  /// if true, displays a delete icon in the chip
+  final bool chipCanDelete;
+
+  /// spacing between chips
+  final double chipSpacing;
+
+  final double maxScrollViewHeight;
+
+  /// text overflow behavior
+  final TextOverflow textOverflow;
+
+  /// style for chip text/label
+  final TextStyle? chipTextStyle;
+
+  /// background color of the chip
+  final Color? chipBackgroundColor;
+
+  /// Color for delete icon in the chip
+  final Color? chipDeleteIconColor;
+
+  final ValueChanged<String?>? onChipSelected;
+
+  final ValueChanged<String?>? onChipDelete;
+
+  const FlutterChips({
+    super.key,
+    this.enabled = true,
+    this.chipCanDelete = false,
+    this.chipSpacing = 5.0,
+    this.maxScrollViewHeight = 75,
+    this.textOverflow = TextOverflow.clip,
+    required this.controller,
+    required this.onChanged,
+    this.chipDeleteIcon,
+    this.chipBackgroundColor,
+    this.chipDeleteIconColor,
+    this.chipTextStyle,
+    this.onChipSelected,
+    this.onChipDelete,
+  });
+  @override
+  State<FlutterChips> createState() => FlutterChipsState();
+}
+
+class FlutterChipsState extends State<FlutterChips> {
+  /// remove the chip from the list and calls [widget.onChanged]
+  void deleteChip(String? value) {
+    if (widget.onChipDelete != null) {
+      widget.onChipDelete!(value);
+      return;
+    } else {
+      if (widget.enabled) {
+        setState(() => widget.controller.removeChip(value));
+        widget.onChanged(widget.controller.chips);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: widget.maxScrollViewHeight, // adjust for chip rows
+      child: SingleChildScrollView(
+        scrollDirection: Axis.vertical,
+        child: Wrap(
+          spacing: widget.chipSpacing,
+          runSpacing: widget.chipSpacing,
+          children: widget.controller.chips
+              .map(
+                (e) => GestureDetector(
+                  onTap: () => widget.onChipSelected?.call(e),
+                  child: Chip(
+                    label: Text(e!, overflow: widget.textOverflow),
+                    onDeleted: widget.chipCanDelete
+                        ? () => deleteChip(e)
+                        : null,
+                    deleteIcon: widget.chipDeleteIcon,
+                    backgroundColor: widget.chipBackgroundColor,
+                    labelStyle: widget.chipTextStyle,
+                    deleteIconColor: widget.chipDeleteIconColor,
+                  ),
+                ),
+              )
+              .toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/InputChip/flutter_input_chips.dart
+++ b/lib/widgets/InputChip/flutter_input_chips.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/models/answer.dart';
+import 'package:quizflow/widgets/InputChip/flutter_chips.dart';
+import 'package:quizflow/widgets/InputChip/input_chips_controller.dart';
+
+///
+/// [FlutterInputChips] is a Flutter widget that builds the input field with input chips options
+///
+class FlutterInputChips extends StatefulWidget {
+  final List<Answer> initialValue;
+
+  /// returns a list of string on inout field submitted
+  final ValueChanged<Set<String?>> onChanged;
+
+  /// number of maximum chips
+  final int? maxChips;
+
+  /// callback when the maximum number of chips is reached
+  final VoidCallback? onMaxChipsReached;
+
+  /// enables the input field and chip delete ability
+  final bool enabled;
+
+  /// inout field action
+  final TextInputAction inputAction;
+
+  /// keyboard appearance
+  final Brightness keyboardAppearance;
+
+  /// autofocus the inout field
+  final bool autofocus;
+
+  /// text capitalization type for the input field keyboard
+  final TextCapitalization textCapitalization;
+
+  /// text input decoration
+  final InputDecoration inputDecoration;
+
+  /// text overflow behavior
+  final TextOverflow textOverflow;
+
+  /// keyboard input type
+  final TextInputType inputType;
+
+  /// parent container padding
+  final EdgeInsets padding;
+  // padding container decoration
+  final BoxDecoration? decoration;
+
+  /// spacing between chips
+  final double chipSpacing;
+
+  /// style for chip text/label
+  final TextStyle? chipTextStyle;
+
+  /// background color of the chip
+  final Color? chipBackgroundColor;
+
+  /// custom delete icon
+  final Widget? chipDeleteIcon;
+
+  /// if true, displays a delete icon in the chip
+  final bool chipCanDelete;
+
+  /// Color for delete icon in the chip
+  final Color? chipDeleteIconColor;
+
+  /// controller for the input field
+  final InputChipsController? controller;
+
+  final String? automaticChipValue;
+
+  const FlutterInputChips({
+    super.key,
+    required this.onChanged,
+    this.initialValue = const [],
+    this.enabled = true,
+    this.inputAction = TextInputAction.done,
+    this.keyboardAppearance = Brightness.light,
+    this.textCapitalization = TextCapitalization.none,
+    this.autofocus = false,
+    this.inputDecoration = const InputDecoration(),
+    this.textOverflow = TextOverflow.clip,
+    this.inputType = TextInputType.text,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+    this.chipCanDelete = true,
+    this.chipSpacing = 5,
+    this.automaticChipValue,
+    this.maxChips,
+    this.decoration,
+    this.chipTextStyle,
+    this.chipBackgroundColor,
+    this.chipDeleteIcon,
+    this.chipDeleteIconColor,
+    this.controller,
+    this.onMaxChipsReached,
+  }) : assert(maxChips == null || initialValue.length <= maxChips);
+
+  @override
+  State<FlutterInputChips> createState() => FlutterInputChipsState();
+}
+
+class FlutterInputChipsState extends State<FlutterInputChips> {
+  /// controller for the input field
+  late final InputChipsController controller;
+
+  bool moreThanOneChip = true;
+
+  /// checks whether the chips has reached the maximum number of chips allowed
+  bool get _hasReachedMaxChips =>
+      widget.maxChips != null && controller.chips.length >= widget.maxChips!;
+
+  @override
+  void initState() {
+    controller = widget.controller ?? InputChipsController(widget.initialValue);
+    moreThanOneChip = controller.chips.length > 1;
+    super.initState();
+  }
+
+  /// adds the chip to the list, clear the text field and calls [widget.onChanged]
+  void addChip(String value) {
+    if (value.isEmpty || _hasReachedMaxChips) {
+      controller.textController.clear();
+      widget.onMaxChipsReached?.call();
+      return;
+    }
+    setState(() {
+      controller.addChip(value.trim());
+    });
+    controller.textController.clear();
+    moreThanOneChip = true;
+    widget.onChanged(controller.chips);
+  }
+
+  void deleteChip(String? value) {
+    if (widget.enabled) {
+      setState(() => controller.removeChip(value));
+      if (controller.chips.length == 1) {
+        controller.updateText(controller.chips.first);
+        moreThanOneChip = false;
+      }
+      if (value! == controller.text) {
+        controller.textController.clear();
+      }
+      widget.onChanged(controller.chips);
+    }
+  }
+
+  /// sets the selected chip's value to the text field
+  void onChipSelected(String? value) {
+    controller.updateText(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: widget.padding,
+      decoration: widget.decoration,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          moreThanOneChip
+              ? FlutterChips(
+                  key: ValueKey(controller.chips.length),
+                  controller: controller,
+                  onChanged: widget.onChanged,
+                  enabled: widget.enabled,
+                  chipCanDelete: widget.chipCanDelete,
+                  chipSpacing: widget.chipSpacing,
+                  textOverflow: widget.textOverflow,
+                  chipDeleteIcon: widget.chipDeleteIcon,
+                  chipBackgroundColor: widget.chipBackgroundColor,
+                  chipDeleteIconColor: widget.chipDeleteIconColor,
+                  chipTextStyle: widget.chipTextStyle,
+                  onChipSelected: onChipSelected,
+                  onChipDelete: deleteChip,
+                )
+              : const SizedBox.shrink(),
+          TextField(
+            controller: controller.textController,
+            onSubmitted: (value) {
+              addChip(value);
+            },
+            onChanged: (value) {
+              if (widget.automaticChipValue != null &&
+                  value.contains(widget.automaticChipValue!)) {
+                addChip(value.replaceAll(widget.automaticChipValue!, ""));
+              }
+            },
+            onEditingComplete: () {}, // this prevents keyboard from closing
+            decoration: widget.inputDecoration,
+            textInputAction: widget.inputAction,
+            keyboardType: widget.inputType,
+            keyboardAppearance: widget.keyboardAppearance,
+            textCapitalization: widget.textCapitalization,
+            enabled: widget.enabled,
+            autofocus: widget.autofocus,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/InputChip/input_chips_controller.dart
+++ b/lib/widgets/InputChip/input_chips_controller.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:quizflow/models/answer.dart';
+import 'package:quizflow/widgets/InputChip/chips_controller.dart';
+
+class InputChipsController extends ChipsController {
+  final TextEditingController textController = TextEditingController();
+
+  InputChipsController([super.initialChips]);
+
+  String get text => textController.text;
+
+  void updateText(String? text) {
+    textController.text = text!;
+  }
+
+  @override
+  void addAllChips(List<Answer> chips) {
+    super.addAllChips(chips);
+    if (chips.length > 1) {
+      textController.text = chips.last.answer!;
+    } else if (chips.length == 1) {
+      textController.text = chips.first.answer!;
+    }
+  }
+}

--- a/lib/widgets/flashcard.dart
+++ b/lib/widgets/flashcard.dart
@@ -1,7 +1,11 @@
 import 'package:flip_card/flip_card.dart';
 import 'package:flutter/material.dart';
+import 'package:quizflow/models/answer.dart';
 import 'package:quizflow/models/word.dart';
+import 'package:quizflow/utilities/database.dart';
 import 'package:quizflow/utilities/tts.dart';
+import 'package:quizflow/widgets/InputChip/chips_controller.dart';
+import 'package:quizflow/widgets/InputChip/flutter_chips.dart';
 
 class FlashCard extends StatefulWidget {
   final Word word;
@@ -10,13 +14,14 @@ class FlashCard extends StatefulWidget {
   final void Function(DismissUpdateDetails)? onDismissibleUpdate;
   final void Function(bool)? onFlip;
 
-  const FlashCard(
-      {super.key,
-      required this.word,
-      required this.onSwipeLeft,
-      required this.onSwipeRight,
-      this.onFlip,
-      this.onDismissibleUpdate});
+  const FlashCard({
+    super.key,
+    required this.word,
+    required this.onSwipeLeft,
+    required this.onSwipeRight,
+    this.onFlip,
+    this.onDismissibleUpdate,
+  });
 
   @override
   FlashCardState createState() => FlashCardState();
@@ -31,41 +36,80 @@ class FlashCardState extends State<FlashCard> {
     super.initState();
   }
 
+  Future<Widget> getFlipCard() async {
+    List<Answer> answers = await DatabaseService.getAnswersFromWord(
+      widget.word.id!,
+    );
+    late Widget cardContent;
+
+    if (answers.length == 1) {
+      cardContent = Text(
+        answers.first.answer ?? "",
+        style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
+      );
+    } else {
+      ChipsController controller = ChipsController(answers);
+      cardContent = FlutterChips(
+        controller: controller,
+        onChanged: (v) {},
+        onChipSelected: (value) {
+          TTS().speech(value ?? "");
+        },
+        maxScrollViewHeight: 320,
+      );
+    }
+
+    return FlipCard(
+      onFlipDone: (isFront) => widget.onFlip,
+      direction: FlipDirection.HORIZONTAL,
+      front: FlashcardCard(
+        cardContent: Text(
+          widget.word.word ?? "",
+          style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
+        ),
+        onTapSpeech: () => TTS().speech(widget.word.word ?? ""),
+      ),
+      back: FlashcardCard(cardContent: cardContent),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Dismissible(
-        onUpdate: widget.onDismissibleUpdate,
-        onDismissed: (direction) {
-          direction == DismissDirection.endToStart
-              ? widget.onSwipeLeft(widget.word)
-              : widget.onSwipeRight(widget.word);
+      onUpdate: widget.onDismissibleUpdate,
+      onDismissed: (direction) {
+        direction == DismissDirection.endToStart
+            ? widget.onSwipeLeft(widget.word)
+            : widget.onSwipeRight(widget.word);
+      },
+      key: UniqueKey(),
+      child: GestureDetector(
+        onTap: () {
+          setState(() {
+            flashCardFace = !flashCardFace;
+          });
         },
-        key: UniqueKey(),
-        child: GestureDetector(
-            onTap: () {
-              setState(() {
-                flashCardFace = !flashCardFace;
-              });
-            },
-            child: FlipCard(
-                onFlipDone: (isFront) => widget.onFlip,
-                direction: FlipDirection.HORIZONTAL,
-                front: FlashcardCard(
-                  cardContent: widget.word.word ?? "",
-                  onTapSpeech: () => TTS().speech(widget.word.word ?? ""),
-                ),
-                back: FlashcardCard(
-                  cardContent: widget.word.answer ?? "",
-                  onTapSpeech: () => TTS().speech(widget.word.answer ?? ""),
-                ))));
+        child: FutureBuilder<Widget>(
+          future: getFlipCard(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (snapshot.hasError) {
+              return Center(child: Text('Error: ${snapshot.error}'));
+            } else {
+              return snapshot.data!;
+            }
+          },
+        ),
+      ),
+    );
   }
 }
 
 class FlashcardCard extends StatelessWidget {
-  final String cardContent;
-  final void Function() onTapSpeech;
-  const FlashcardCard(
-      {super.key, required this.cardContent, required this.onTapSpeech});
+  final Widget cardContent;
+  final void Function()? onTapSpeech;
+  const FlashcardCard({super.key, required this.cardContent, this.onTapSpeech});
 
   @override
   Widget build(BuildContext context) {
@@ -73,27 +117,17 @@ class FlashcardCard extends StatelessWidget {
       elevation: 20,
       child: Stack(
         children: [
-          SizedBox(
-            height: 400,
-            width: 300,
-            child: Center(
-              child: Text(
-                cardContent,
-                style: const TextStyle(
-                  fontSize: 40,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            top: 10,
-            right: 10,
-            child: IconButton(
-              icon: const Icon(Icons.volume_up),
-              onPressed: onTapSpeech,
-            ),
-          ),
+          SizedBox(height: 400, width: 300, child: Center(child: cardContent)),
+          onTapSpeech != null
+              ? Positioned(
+                  top: 10,
+                  right: 10,
+                  child: IconButton(
+                    icon: const Icon(Icons.volume_up),
+                    onPressed: onTapSpeech,
+                  ),
+                )
+              : const SizedBox.shrink(),
         ],
       ),
     );

--- a/lib/widgets/word_card.dart
+++ b/lib/widgets/word_card.dart
@@ -1,9 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:quizflow/models/answer.dart';
 import 'package:quizflow/models/word.dart';
+import 'package:quizflow/utilities/database.dart';
+import 'package:quizflow/widgets/InputChip/chips_controller.dart';
+import 'package:quizflow/widgets/InputChip/flutter_chips.dart';
 
 class WordCard extends StatelessWidget {
   final Word word;
   const WordCard({super.key, required this.word});
+
+  Future<Widget> getAnswers() async {
+    List<Answer> answers = await DatabaseService.getAnswersFromWord(word.id!);
+
+    if (answers.length == 1) {
+      return Text(
+        answers.first.answer ?? "",
+        style: const TextStyle(fontSize: 20),
+      );
+    }
+
+    ChipsController controller = ChipsController(answers);
+
+    return FlutterChips(controller: controller, onChanged: (v) {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,13 +32,19 @@ class WordCard extends StatelessWidget {
         child: Column(
           children: [
             Text(word.word ?? "", style: const TextStyle(fontSize: 20)),
-            const SizedBox(
-              height: 20,
+            const SizedBox(height: 20),
+            FutureBuilder<Widget>(
+              future: getAnswers(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  return snapshot.data!;
+                }
+              },
             ),
-            Text(
-              word.answer ?? "",
-              style: const TextStyle(fontSize: 20),
-            )
           ],
         ),
       ),

--- a/lib/widgets/word_editor_card.dart
+++ b/lib/widgets/word_editor_card.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:quizflow/widgets/InputChip/flutter_input_chips.dart';
+import 'package:quizflow/widgets/InputChip/input_chips_controller.dart';
 
 class WordEditorCard extends StatefulWidget {
   final TextEditingController questionController;
-  final TextEditingController answerController;
+  final InputChipsController answerController;
 
-  const WordEditorCard(
-      {super.key,
-      required this.questionController,
-      required this.answerController});
+  const WordEditorCard({
+    super.key,
+    required this.questionController,
+    required this.answerController,
+  });
 
   @override
   State<WordEditorCard> createState() => _WordEditorCardState();
@@ -28,13 +31,15 @@ class _WordEditorCardState extends State<WordEditorCard> {
                 labelText: 'Question',
               ),
             ),
-            TextField(
+            FlutterInputChips(
               controller: widget.answerController,
-              decoration: const InputDecoration(
+              onChanged: (v) {},
+              padding: const EdgeInsets.all(0),
+              inputDecoration: const InputDecoration(
                 border: UnderlineInputBorder(),
                 labelText: 'Answer',
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   flutter_archive: ^6.0.3
   flutter_tts: ^4.2.2
   flutter_langdetect: ^0.0.2
+  rapidfuzz: ^0.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This PR introduces a major structural change to how answers are handled in QuizFlow:

### ✅ Key Changes

- **Data Model:**
  - Added a new `Answer` model to store multiple answers per word.
  - Removed the `definition` field from the `Word` model.

- **Database:**
  - Incremented DB version from 2 → 3.
  - Migrated existing data:
    - Renamed `Words` table.
    - Created new `Words` table (without `definition`).
    - Created new `Answers` table.
    - Transferred existing definitions from old `Words` into `Answers`.

- **UI Components:**
  - Added `FlutterChips`, `FlutterInputChips`, and related controllers to handle multi-answer input/output (Full credits to [flutter_input_chips](https://github.com/imsujan276/flutter_input_chips)).
  - Reworked flashcard UI to show chips when multiple answers are present.
  - Updated `WritePage` to validate answers against multiple options and show [best match](https://pub.dev/packages/rapidfuzz) if incorrect.
  - Modified `WordEditorCard` to support multi-answer entry via chips.

- **Other Logic:**
  - Adjusted import/export to account for multiple answers.
  - Updated word display components to fetch and render multiple answers.

### 💥 Why?

Previously, each word was limited to a single answer. This was restrictive for vocabulary learning where synonyms or variants are valid/required. With this update, users can define and practice multiple correct answers for a single word.

### 🧪 Notes

- Old data will be preserved and transformed on DB migration.
- UI is backward compatible and falls back gracefully when only one answer exists.
- "Show all" toggle in `WritePage` helps learners see all accepted answers after a wrong input.
